### PR TITLE
docs: fix typos in README and kotlinc test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # A Dev Container Features Collection
 
 This repository is based on the
-[the `devcontainers/features` repository](https://github.com/devcontainers/features).
+[`devcontainers/features` repository](https://github.com/devcontainers/features).
 
 ## Contents
 
@@ -11,7 +11,7 @@ Install the modern shell utilities:
 
 - [eza](https://eza.rocks/), _ls_ alternative (previously [exa](https://github.com/ogham/exa) was bundled)
 - [fd](https://github.com/sharkdp/fd), _find_ alternative
-- [ag (The Silver Seacher)](https://github.com/ggreer/the_silver_searcher),
+- [ag (The Silver Searcher)](https://github.com/ggreer/the_silver_searcher),
   _grep_ alternative
 - [bat](https://github.com/sharkdp/bat), _cat_ alternative
 

--- a/test/kotlinc/test.sh
+++ b/test/kotlinc/test.sh
@@ -6,7 +6,7 @@ set -e
 rm -rf /var/lib/apt/lists/*
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run as root to be able to installe dependencies, changing to sudo when installing.'
+    echo -e 'Script must be run as root to be able to install dependencies, changing to sudo when installing.'
 fi
 
 apt_get_update() {
@@ -41,7 +41,7 @@ echo $PATH
 
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
-check "ktlint: ktlint --version'" ktlint --version
+check "ktlint: 'ktlint --version'" ktlint --version
 check "kotlinc: 'kotlinc --version'" kotlinc -version
 
 # Report results


### PR DESCRIPTION
## Summary
- Fix \"Silver Seacher\" -> \"Silver Searcher\" in the top-level README.
- Drop a duplicated \"the\" in the intro link to `devcontainers/features`.
- Fix \"installe\" -> \"install\" in the kotlinc test root-check message.
- Balance the stray apostrophe in the ktlint check description so it matches the kotlinc line.

## Test plan
- [ ] Read README.md to confirm typos are gone.
- [ ] Existing CI runs `test/kotlinc/test.sh` and continues to pass.