### PR TITLE
refactor: harden feature install scripts

### DIFF
--- a/src/kotlinc/install.sh
+++ b/src/kotlinc/install.sh
@@ -62,7 +62,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 echo "Step 4, check if architecture is supported"
 architecture="$(uname -m)"
-if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "x86_64" ] && [ "${architecture}" != "arm64" ] && [ "${architecture}" != "aarch64" ]; then
+if [ "${architecture}" != "x86_64" ] && [ "${architecture}" != "aarch64" ]; then
     echo "(!) Architecture $architecture unsupported"
     exit 1
 fi

--- a/src/modern-shell-utils/install.sh
+++ b/src/modern-shell-utils/install.sh
@@ -56,7 +56,7 @@ if [ "${architecture}" != "x86_64" ] && [ "${architecture}" != "aarch64" ]; then
 fi
 
 
-echo "Step 4.5, add apt repo deb.gierens.de to get 'eza'. To be removed when 'eza' is available in mainstream repo"
+echo "Step 5, add apt repo deb.gierens.de to get 'eza'. To be removed when 'eza' is available in mainstream repo"
 check_packages ca-certificates gpg wget
 mkdir -p /etc/apt/keyrings
 wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
@@ -65,11 +65,11 @@ chmod 644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
 apt-get update -y
 
 
-echo "Step 5, install packages"
+echo "Step 6, install packages"
 check_packages eza fd-find silversearcher-ag bat
 
-ln -s /usr/bin/fdfind /usr/local/bin/fd
-ln -s /usr/bin/batcat /usr/local/bin/bat
+ln -sf /usr/bin/fdfind /usr/local/bin/fd
+ln -sf /usr/bin/batcat /usr/local/bin/bat
 
 
 # Clean up

--- a/src/modern-shell-utils/install.sh
+++ b/src/modern-shell-utils/install.sh
@@ -50,7 +50,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 echo "Step 4, check if architecture is supported"
 architecture="$(uname -m)"
-if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "x86_64" ] && [ "${architecture}" != "arm64" ] && [ "${architecture}" != "aarch64" ]; then
+if [ "${architecture}" != "x86_64" ] && [ "${architecture}" != "aarch64" ]; then
     echo "(!) Architecture $architecture unsupported"
     exit 1
 fi


### PR DESCRIPTION
## Summary
- Drop unreachable `amd64` / `arm64` branches from the architecture check in both `kotlinc` and `modern-shell-utils`. `uname -m` on Linux returns `x86_64` or `aarch64`; the dpkg/macOS spellings can never match.
- Renumber `modern-shell-utils` steps so the trace reads `Step 1..Step 6` instead of a `Step 4.5` interlude.
- Use `ln -sf` for the `fd` / `bat` symlinks so re-running the script does not fail with \"File exists\" when those symlinks already exist (e.g. when the feature is rebuilt over an existing layer).

## Test plan
- [ ] CI workflow `test.yaml` runs both features on `debian:latest`, `ubuntu:latest`, and `mcr.microsoft.com/devcontainers/base:ubuntu` and the per-feature `test.sh` checks pass.
- [ ] Manually verify on an arm64 host that the arch check still passes (it should — `aarch64` is preserved).