### PR TITLE
chore(kotlinc): bump installsAfter common-utils to v2

### DIFF
--- a/src/kotlinc/devcontainer-feature.json
+++ b/src/kotlinc/devcontainer-feature.json
@@ -4,7 +4,7 @@
   "version": "1.1.0",
   "description": "Kotlin compiler and linter (requires Java)",
   "installsAfter": [
-    "ghcr.io/devcontainers/features/common-utils:1",
+    "ghcr.io/devcontainers/features/common-utils:2",
     "ghcr.io/devcontainers/features/java:1"
   ]
 }


### PR DESCRIPTION
## Summary
- `src/kotlinc/devcontainer-feature.json` hints that the feature should install after `ghcr.io/devcontainers/features/common-utils:1`, but the major is now `:2` (the repo's own `.devcontainer.json` already pulls in `:2`). Update the hint so it actually matches the major in use.

## Test plan
- [ ] CI feature build still succeeds.
- [ ] No behavioural change expected at runtime; `installsAfter` only affects install ordering when both features are present.